### PR TITLE
Remove asp prefix from style links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="asp/css/bootstrap.min.css">
-    <link href="asp/css/style.css" rel="stylesheet" type="text/css">
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+    <link href="css/style.css" rel="stylesheet" type="text/css">
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>


### PR DESCRIPTION
Resolves https://github.com/Epidiah/asp/issues/1

# What does this do?

This just removes the `asp/` prefix on the CSS links in the header of `index.html` in `docs`.

<img width="496" alt="Screen Shot 2022-09-02 at 11 23 39 AM" src="https://user-images.githubusercontent.com/1731429/188223224-49c15ae2-9a12-43a5-ad0c-45054da5fd55.png">

# Alternative

The other alternative is applying a root `/` ahead of the `asp` prefix as so:

Before
```html
<link rel="stylesheet" type="text/css" href="asp/css/bootstrap.min.css">
<link href="asp/css/style.css" rel="stylesheet" type="text/css">
```

After
```html
<link rel="stylesheet" type="text/css" href="/asp/css/bootstrap.min.css">
<link href="/asp/css/style.css" rel="stylesheet" type="text/css">
```

I went with the option to use the relative version of `css/...` as the path because it matches expectations of the development environment and the colocation of `index.html` and the `css/` folder. After all, the `asp/` prefix appears to be specific to the GitHub pages deployment and may not exist in other deployments of this site.

# More info

It's not clear whether there is a build step/process/script which generates this index.html or if it is manually maintained. It seems manual, but please correct me if I'm wrong and if there's a different source for where this `asp/` value is coming from.

